### PR TITLE
20210629: インメモリ上のユーザーで認証できるようにする

### DIFF
--- a/src/main/java/springsecuritysample/security/config/Config.java
+++ b/src/main/java/springsecuritysample/security/config/Config.java
@@ -1,23 +1,41 @@
 package springsecuritysample.security.config;
 
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import springsecuritysample.security.UsernamePasswordJsonAuthenticationFilter;
+import springsecuritysample.security.filter.UsernamePasswordJsonAuthenticationFilter;
+import springsecuritysample.security.handler.ApiAuthenticationSuccessHandler;
 
 @EnableWebSecurity
 public class Config extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
-                .addFilterBefore(usernamePasswordJsonAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(usernamePasswordJsonAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .authorizeRequests(customizer ->
+                    customizer
+                        .mvcMatchers("/api/login").permitAll()
+                        .anyRequest().denyAll()
+                )
+                .csrf().disable();
     }
 
-    private UsernamePasswordJsonAuthenticationFilter usernamePasswordJsonAuthenticationFilter() {
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth
+                .inMemoryAuthentication().withUser("taro").password("password123").roles("USER")
+                .and()
+                .passwordEncoder(NoOpPasswordEncoder.getInstance());
+    }
+
+    private UsernamePasswordJsonAuthenticationFilter usernamePasswordJsonAuthenticationFilter() throws Exception {
         UsernamePasswordJsonAuthenticationFilter filter =
-                new UsernamePasswordJsonAuthenticationFilter();
+                new UsernamePasswordJsonAuthenticationFilter(authenticationManager());
         filter.setFilterProcessesUrl("/api/login");
+        filter.setAuthenticationSuccessHandler(new ApiAuthenticationSuccessHandler());
         return filter;
     }
 

--- a/src/main/java/springsecuritysample/security/filter/UsernamePasswordJsonAuthenticationFilter.java
+++ b/src/main/java/springsecuritysample/security/filter/UsernamePasswordJsonAuthenticationFilter.java
@@ -1,6 +1,7 @@
-package springsecuritysample.security;
+package springsecuritysample.security.filter;
 
 import org.json.JSONObject;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -12,6 +13,11 @@ import java.io.IOException;
 import java.util.stream.Collectors;
 
 public class UsernamePasswordJsonAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    public UsernamePasswordJsonAuthenticationFilter(AuthenticationManager authenticationManager) {
+        super(authenticationManager);
+    }
+
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
         try {

--- a/src/main/java/springsecuritysample/security/handler/ApiAuthenticationSuccessHandler.java
+++ b/src/main/java/springsecuritysample/security/handler/ApiAuthenticationSuccessHandler.java
@@ -1,0 +1,19 @@
+package springsecuritysample.security.handler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class ApiAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException, ServletException {
+        response.setStatus(HttpStatus.NO_CONTENT.value());
+        clearAuthenticationAttributes(request);
+    }
+}

--- a/src/test/java/springsecuritysample/security/LoginTest.java
+++ b/src/test/java/springsecuritysample/security/LoginTest.java
@@ -18,10 +18,10 @@ public class LoginTest {
     private MockMvc mockMvc;
 
     @Test
-    void 認証しないとUnAuthorizedを返す() throws Exception {
+    void 認証しないとForbiddenを返す() throws Exception {
         mockMvc.perform(
             MockMvcRequestBuilders.get("/")
-        ).andExpect(status().isUnauthorized());
+        ).andExpect(status().isForbidden());
     }
 
     @Test

--- a/src/test/java/springsecuritysample/security/LoginTest.java
+++ b/src/test/java/springsecuritysample/security/LoginTest.java
@@ -37,4 +37,18 @@ public class LoginTest {
         )
                 .andExpect(status().isNoContent());
     }
+
+    @Test
+    void 誤ったusernameとpasswordだと認証失敗する() throws Exception {
+        String json = "{\n" +
+                "    \"username\": \"taro1\",\n" +
+                "    \"password\": \"password123\"\n" +
+                "}";
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json)
+        )
+                .andExpect(status().isUnauthorized());
+    }
 }


### PR DESCRIPTION
### 概要
インメモリ上のユーザーで認証できるようにしました。

![IMG_6919](https://user-images.githubusercontent.com/54400975/123981200-1eb40680-d9fd-11eb-9b41-85bb6cdb1784.PNG)


### 関連URL
Spring Security リファレンス
https://spring.pleiades.io/spring-security/site/docs/current/reference/html5/#servlet-authentication
